### PR TITLE
refactor(html from file): uses html from file

### DIFF
--- a/src/__tests__/test-parser-test.js
+++ b/src/__tests__/test-parser-test.js
@@ -6,21 +6,34 @@
  *
  * @jest-environment node
  */
+import * as fs from 'fs';
+import * as path from 'path';
 import { JSDOM } from 'jsdom';
 import { TestParser, Itter, GetDomFragment } from '../test-parser';
 import { divTests } from './fixtures/div-requirements';
 
+const DIV_HTML_TO_TEST = path.join(
+  __dirname,
+  './fixtures/div--variant-one.html'
+);
+
 /**
- * Variable representing a demo of a component
- *
- * @todo the HTML should be pulled in from a static HTML file (path.join(__dirname, 'fixtures/div--variant-one.html'))
+ * Variable representing a HTML of a component. Includes _entire_ HTML document.
  * @type {string}
  */
-const divHTML = `<div class="bx--meow bx--meow--variant-one"><span>Meow unique text</span></div>`;
+const divHTML = fs.readFileSync(DIV_HTML_TO_TEST, 'utf8');
 
-// this _should_ be done on a per-variant-demo-file basis via a common `setupDom` function,
-//    but don't want to spend time on JSDom setup for this PR
-const { document } = new JSDOM(divHTML).window;
+/**
+ * Options when creating the window/document from the HTML that's being tested
+ * @type {object}
+ */
+const JSDOMoptions = { resources: 'usable' };
+
+/**
+ * Adjusts global window and document to be from the HTML we're gonna test
+ */
+const { window } = new JSDOM(divHTML, JSDOMoptions);
+global.document = window.document;
 
 describe('TestParser', () => {
   describe('All functions exist', () => {


### PR DESCRIPTION
* uses node fs to get HTML file
* global.window and global.document are from the HTML file in the tests

#### Changelog

**New**

- gets HTML from file
- _should_ get js and css too
- adds window